### PR TITLE
Added in the ability to "restfully" build urls with little work

### DIFF
--- a/phonebook.js
+++ b/phonebook.js
@@ -7,19 +7,22 @@
   */
 
 !function (name, definition) {
-  if (typeof module != 'undefined') module.exports = definition()
-  else if (typeof define == 'function' && typeof define.amd == 'object') define(definition)
-  else this[name] = definition()
+    if (typeof module != 'undefined') module.exports = definition()
+    else if (typeof define == 'function' && typeof define.amd == 'object') define(definition)
+    else this[name] = definition()
 }('Phonebook', function () {
-    function Phonebook(options){
-        this.url      = options.url      || "";
-        this.options  = options.options  || {};
-        this.data     = options.data     || {};
-        this.parent   = options.parent   || null;
+    function Phonebook(options) {
+        this.url = options.url || "";
+        this.options = options.options || {};
+        this.data = options.data || {};
+        this.isRestful = options.isRestful;
+        this.parent = options.parent || null;
+        this.isBase = !this.parent;
     }
 
+    var urlPlaceholderRegex = new RegExp(/\{{1}(\w*)\}{1}/gi);
     Phonebook.prototype = {
-        define: function(object){
+        define: function (object) {
             var key = object.name;
             var url = object.url;
             var method = object.type
@@ -27,60 +30,84 @@
             var options = object.options;
             var allowed;
 
-            if(allowed = !this[key]){
-                this[key] = function(_data, _options){
+            if (allowed = !this[key]) {
+                this[key] = function (_data, _options) {
                     return this.request(method, url, jQuery.extend(data, _data), jQuery.extend(options, _options));
                 };
             }
             return allowed;
         },
 
-        request: function(method, url, data, options){
-            data = data || {};
-            options = options || {};
+        request: function (method, url, data, options) {
+            data = this.buildHash("data", data || {});
+            options = this.buildHash("options", options);
+            url = url || '';
 
-            return jQuery.ajax(jQuery.extend(this.buildHash("options", options), {
-                url: this.getURL() + url,
+            var isGet = method == 'GET',
+                url = this.getURL() + url,
+                placeholders;
+
+            while (placeholders = urlPlaceholderRegex.exec(url)) {
+                var placeholder = placeholders[0],
+                    key = placeholders[1];
+
+                url = url.replace(placeholder, data[key] || '');
+            }
+
+            url = url.replace('//', '/');
+            url = this.isRestful && url[url.length - 1] == '/' ? url.slice(0, -1) : url;
+
+            return jQuery.ajax(jQuery.extend(options, {
+                url: url,
                 type: method,
-                data: this.buildHash("data", data)
+                contentType: !isGet ? 'application/json; charset=utf-8' : undefined,
+                processData: isGet,
+                data: !isGet ? JSON.stringify(data) : data
             }));
         },
 
-        getURL: function(){
-            var prefix = "";
-            if(this.parent){
-                prefix = this.parent.getURL();
+        getURL: function () {
+            var prefix = this.parent ? this.parent.getURL() : '';
+            prefix = (prefix + this.url).replace(/[\/]+/gi, "/");
+
+            if (this.parent && !this.parent.isBase) {
+                prefix += '/{' + this.name + 'Id}';
             }
-            return (prefix + this.url).replace(/[\/]+/gi, "/");
+            else if (this.parent && this.parent.isBase) {
+                prefix += '/{id}';
+            }
+
+            return prefix;
         },
 
-        buildHash: function(key, hash){
+        buildHash: function (key, hash) {
             var all = this[key];
-            if(typeof hash == "function"){
+            if (typeof hash == "function") {
                 hash = hash.bind(hash)();
             }
 
-            if(this.parent){
+            if (this.parent) {
                 all = this.parent.buildHash(key, all);
             }
             return jQuery.extend({}, all, hash);
         },
 
-        addChapter: function(object){
+        addChapter: function (object) {
             var allowed;
             var key = object.name;
-            if(allowed = !this[key]){
-                this[key] = Phonebook.open(jQuery.extend(object, {parent: this}));
+            if (allowed = !this[key]) {
+                this[key] = Phonebook.open(jQuery.extend(object, { parent: this, isRestful: this.isRestful }));
+                this[key].name = key;
             }
             return allowed;
         },
 
-        get:     function(url, data, options){ return this.request("GET",    url, data, options); },
-        post:    function(url, data, options){ return this.request("POST",   url, data, options); },
-        put:     function(url, data, options){ return this.request("PUT",    url, data, options); },
-        destroy: function(url, data, options){ return this.request("DELETE", url, data, options); }
+        get: function (data, url, options) { return this.request("GET", url, data, options); },
+        post: function (data, url, options) { return this.request("POST", url, data, options); },
+        put: function (data, url, options) { return this.request("PUT", url, data, options); },
+        destroy: function (data, url, options) { return this.request("DELETE", url, data, options); },
     };
-    Phonebook.open = function(options){ return new Phonebook(options); };
+    Phonebook.open = function (options) { return new Phonebook(options); };
     Phonebook.version = "1.0";
 
     return Phonebook;


### PR DESCRIPTION
This is actually being used in a real product. I changed the api signature as I felt it was "broken". I didn't want to continually declare `url = ''`, which would look like `.get('',data)` and my urls were automatically being built for me via convention through the data.

By building the url restfully you can simplify code like `users.get({id: 10})` and have that map to /users/10 all without extra work.
